### PR TITLE
Qt 5.11 beta: xxxwidget.h: include QAction explicitely

### DIFF
--- a/src/devicewidget.cc
+++ b/src/devicewidget.cc
@@ -28,6 +28,7 @@
 #include "devicewidget.h"
 #include "channel.h"
 #include <sstream>
+#include <QAction>
 #include <QLabel>
 #include <QMessageBox>
 #include <QInputDialog>

--- a/src/devicewidget.h
+++ b/src/devicewidget.h
@@ -30,6 +30,7 @@
 
 class MainWindow;
 class Channel;
+class QAction;
 
 class DeviceWidget : public MinimalStreamWidget, public Ui::DeviceWidget {
     Q_OBJECT

--- a/src/sinkinputwidget.h
+++ b/src/sinkinputwidget.h
@@ -24,6 +24,7 @@
 #include "pavucontrol.h"
 
 #include "streamwidget.h"
+#include <QAction>
 
 class MainWindow;
 class QMenu;

--- a/src/sourceoutputwidget.h
+++ b/src/sourceoutputwidget.h
@@ -24,6 +24,7 @@
 #include "pavucontrol.h"
 
 #include "streamwidget.h"
+#include <QAction>
 
 class MainWindow;
 class QMenu;

--- a/src/streamwidget.cc
+++ b/src/streamwidget.cc
@@ -25,7 +25,7 @@
 #include "streamwidget.h"
 #include "mainwindow.h"
 #include "channel.h"
-
+#include <QAction>
 
 /*** StreamWidget ***/
 StreamWidget::StreamWidget(MainWindow *parent) :

--- a/src/streamwidget.h
+++ b/src/streamwidget.h
@@ -29,6 +29,7 @@
 
 class MainWindow;
 class Channel;
+class QAction;
 
 class StreamWidget : public MinimalStreamWidget, public Ui::StreamWidget {
     Q_OBJECT


### PR DESCRIPTION
5.11 Qt headers do not indirectly include QAction resulting in compile
time errors like:
| devicewidget.cc:40:52: error: invalid use of incomplete type 'class QAction'

Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>