### PR TITLE
Treat the 'off' card profile specifically

### DIFF
--- a/src/cardwidget.cc
+++ b/src/cardwidget.cc
@@ -29,44 +29,65 @@ CardWidget::CardWidget(QWidget* parent) :
     QWidget(parent) {
     setupUi(this);
     connect(profileList, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &CardWidget::onProfileChange);
+    connect(profileCB, &QAbstractButton::toggled, this, &CardWidget::onProfileCheck);
 }
 
 
 void CardWidget::prepareMenu() {
     int idx = 0;
-    int active_idx = -1;
+    const bool off = activeProfile == noInOutProfile;
 
     profileList->clear();
     /* Fill the ComboBox */
     for (uint32_t i = 0; i < profiles.size(); ++i) {
         const auto& profile = profiles[i];
         QByteArray name = profile.first;
+        // skip the "off" profile
+        if (name == noInOutProfile)
+            continue;
         QString desc = QString::fromUtf8(profile.second);
         profileList->addItem(desc, name);
-        if (profile.first == activeProfile)
-          active_idx = idx;
-        idx++;
+        if (profile.first == activeProfile
+                || (off && profile.first == lastActiveProfile)
+                )
+        {
+            profileList->setCurrentIndex(idx);
+            lastActiveProfile = profile.first;
+        }
+        ++idx;
     }
 
-    if (active_idx >= 0)
-        profileList->setCurrentIndex(active_idx);
+    profileCB->setChecked(!off);
+}
 
+void CardWidget::changeProfile(const QByteArray & name)
+{
+    pa_operation* o;
+
+    if (!(o = pa_context_set_card_profile_by_index(get_context(), index, name.constData(), NULL, NULL))) {
+        show_error(tr("pa_context_set_card_profile_by_index() failed").toUtf8().constData());
+        return;
+    }
+
+    pa_operation_unref(o);
 }
 
 void CardWidget::onProfileChange(int active) {
     if (updating)
         return;
 
-    if (active != -1) {
-        QString desc = profileList->itemText(active);
-        QByteArray name = profileList->itemData(active).toByteArray();
-        pa_operation* o;
+    if (active != -1)
+        changeProfile(profileList->itemData(active).toByteArray());
+}
 
-        if (!(o = pa_context_set_card_profile_by_index(get_context(), index, name.constData(), NULL, NULL))) {
-            show_error(tr("pa_context_set_card_profile_by_index() failed").toUtf8().constData());
-            return;
-        }
+void CardWidget::onProfileCheck(bool on)
+{
+    if (updating)
+        return;
 
-        pa_operation_unref(o);
-    }
+    if (on)
+        onProfileChange(profileList->currentIndex());
+    else
+        changeProfile(noInOutProfile);
+
 }

--- a/src/cardwidget.h
+++ b/src/cardwidget.h
@@ -48,13 +48,17 @@ public:
     std::vector< std::pair<QByteArray,QByteArray> > profiles;
     std::map<QByteArray, PortInfo> ports;
     QByteArray activeProfile;
+    QByteArray noInOutProfile;
+    QByteArray lastActiveProfile;
     bool hasSinks;
     bool hasSources;
 
     void prepareMenu();
 
 protected:
-  virtual void onProfileChange(int active);
+    void changeProfile(const QByteArray & name);
+    void onProfileChange(int active);
+    void onProfileCheck(bool on);
 
 };
 

--- a/src/cardwidget.ui
+++ b/src/cardwidget.ui
@@ -13,9 +13,9 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="nameHLayout" stretch="0,1">
      <item>
       <widget class="QLabel" name="iconImage">
        <property name="text">
@@ -32,17 +32,28 @@
      </item>
     </layout>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Profile:</string>
-     </property>
-    </widget>
+   <item>
+    <layout class="QHBoxLayout" name="profileHLayout" stretch="0,0,1">
+     <item>
+      <widget class="QCheckBox" name="profileCB">
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="profileLabel">
+       <property name="text">
+        <string>Profile:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="profileList"/>
+     </item>
+    </layout>
    </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="profileList"/>
-   </item>
-   <item row="2" column="0" colspan="2">
+   <item>
     <widget class="Line" name="line">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -52,5 +63,38 @@
   </layout>
  </widget>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>profileCB</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>profileLabel</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>137</x>
+     <y>47</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>147</x>
+     <y>47</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>profileCB</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>profileList</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>137</x>
+     <y>47</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>315</x>
+     <y>47</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/src/devicewidget.ui
+++ b/src/devicewidget.ui
@@ -96,7 +96,7 @@
    </item>
    <item>
     <widget class="QWidget" name="portSelect" native="true">
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1">
       <item>
        <widget class="QLabel" name="label_3">
         <property name="text">

--- a/src/mainwindow.cc
+++ b/src/mainwindow.cc
@@ -258,6 +258,8 @@ void MainWindow::updateCard(const pa_card_info &info) {
             desc += tr(" (unavailable)").toUtf8().constData();
 
         w->profiles.push_back(std::pair<QByteArray,QByteArray>(p_profile->name, desc));
+        if (p_profile->n_sinks == 0 && p_profile->n_sources == 0)
+            w->noInOutProfile = p_profile->name;
     }
 
     w->activeProfile = info.active_profile ? info.active_profile->name : "";


### PR DESCRIPTION
Present the 'off' profile as enable/disable checkbox in GUI. Also
remember the last "active" profile to activate it after enabling.

Note: after restarting the application we have no way to know which
profile was active before the 'off' profile (if 'off' profile is
activated at application startup).

ref. #84 