### PR TITLE
Avoid going out of array bounds when iterating over profiles

### DIFF
--- a/src/mainwindow.cc
+++ b/src/mainwindow.cc
@@ -209,7 +209,7 @@ void MainWindow::updateCard(const pa_card_info &info) {
 
     w->hasSinks = w->hasSources = false;
     profile_priorities.clear();
-    for (pa_card_profile_info2 ** p_profile = info.profiles2; *p_profile != nullptr; ++p_profile) {
+    for (pa_card_profile_info2 ** p_profile = info.profiles2; p_profile && *p_profile != nullptr; ++p_profile) {
         w->hasSinks = w->hasSinks || ((*p_profile)->n_sinks > 0);
         w->hasSources = w->hasSources || ((*p_profile)->n_sources > 0);
         profile_priorities.insert(*p_profile);
@@ -225,7 +225,7 @@ void MainWindow::updateCard(const pa_card_info &info) {
         p.available = info.ports[i]->available;
         p.direction = info.ports[i]->direction;
         p.latency_offset = info.ports[i]->latency_offset;
-        for (pa_card_profile_info2 ** p_profile = info.ports[i]->profiles2; *p_profile != nullptr; ++p_profile)
+        for (pa_card_profile_info2 ** p_profile = info.ports[i]->profiles2; p_profile && *p_profile != nullptr; ++p_profile)
             p.profiles.push_back((*p_profile)->name);
 
         w->ports[p.name] = p;


### PR DESCRIPTION
For a while now, when connecting to my Bluetooth speaker, pavucontrol-qt would crash and fail to start again.

Running strace revealed that no matching icon file could be found, so I went digging. While I don't know why I have no icon candidate installed, I found some questionable for loops in commit 9f10fb4afffffff21e1cbb370989b83f63170e78. Reverting the second one to the old format while still switching to profile2 did the trick. I altered both for good measure, though.

This is a very quick and simple fix, but perhaps that's enough. I am not entirely sure if `n_profiles` was deprecated as well, but I would be surprised if it was.

On a final note, it does not give me a default icon, but I guess that is okay. 

Cheers!


