### PR TITLE
GUI fixes: Elide playback name label if needed and…

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ set(pavucontrol-qt_HDRS
     sourceoutputwidget.h
     sourcewidget.h
     streamwidget.h
+    elidinglabel.h
 )
 
 set(pavucontrol-qt_SRCS
@@ -31,6 +32,7 @@ set(pavucontrol-qt_SRCS
     sourceoutputwidget.cc
     sourcewidget.cc
     streamwidget.cc
+    elidinglabel.cc
 )
 
 set(pavucontrol-qt_UI

--- a/src/elidinglabel.cc
+++ b/src/elidinglabel.cc
@@ -1,0 +1,46 @@
+/***
+  This file is part of pavucontrol-qt.
+
+  pavucontrol-qt is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  pavucontrol-qt is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with pavucontrol-qt. If not, see <https://www.gnu.org/licenses/>.
+***/
+
+#include "elidinglabel.h"
+#include <QPainter>
+#include <QStyleOption>
+
+ElidingLabel::ElidingLabel(QWidget *parent, Qt::WindowFlags f):
+    QLabel(parent, f),
+    lastWidth_(0) {
+    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+    // set a min width to prevent the window from widening with long texts
+    setMinimumWidth(fontMetrics().averageCharWidth() * 10);
+}
+
+// A simplified version of QLabel::paintEvent() without pixmap or shortcut but with eliding
+void ElidingLabel::paintEvent(QPaintEvent */*event*/) {
+    QRect cr = contentsRect().adjusted(margin(), margin(), -margin(), -margin());
+    QString txt = text();
+    // if the text is changed or its rect is resized (due to window resizing),
+    // find whether it needs to be elided...
+    if (txt != lastText_ || cr.width() != lastWidth_) {
+        lastText_ = txt;
+        lastWidth_ = cr.width();
+        elidedText_ = fontMetrics().elidedText(txt, Qt::ElideMiddle, cr.width());
+    }
+    // ... then, draw the (elided) text */
+    QPainter painter(this);
+    QStyleOption opt;
+    opt.initFrom(this);
+    style()->drawItemText(&painter, cr, alignment(), opt.palette, isEnabled(), elidedText_, foregroundRole());
+}

--- a/src/elidinglabel.h
+++ b/src/elidinglabel.h
@@ -1,0 +1,38 @@
+/***
+  This file is part of pavucontrol-qt.
+
+  pavucontrol-qt is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  pavucontrol-qt is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with pavucontrol-qt. If not, see <https://www.gnu.org/licenses/>.
+***/
+
+#ifndef elidinglabel_h
+#define elidinglabel_h
+
+#include <QLabel>
+
+class ElidingLabel : public QLabel {
+  Q_OBJECT
+
+public:
+    explicit ElidingLabel(QWidget *parent = 0, Qt::WindowFlags f = Qt::WindowFlags());
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+
+private:
+    QString elidedText_;
+    QString lastText_;
+    int lastWidth_;
+};
+
+#endif // elidinglabel_h

--- a/src/minimalstreamwidget.cc
+++ b/src/minimalstreamwidget.cc
@@ -38,7 +38,6 @@ MinimalStreamWidget::MinimalStreamWidget(QWidget *parent) :
     volumeMeterVisible(true) {
 
     peakProgressBar->setTextVisible(false);
-    peakProgressBar->setMaximumHeight(4 /* FIXME: hardcoded */);
     peakProgressBar->hide();
 }
 

--- a/src/streamwidget.ui
+++ b/src/streamwidget.ui
@@ -27,7 +27,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="nameLabel">
+      <widget class="ElidingLabel" name="nameLabel">
        <property name="text">
         <string>Device Title</string>
        </property>
@@ -103,6 +103,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ElidingLabel</class>
+   <extends>QLabel</extends>
+   <header>elidinglabel.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
If the name is too long, elide it centrally, so that a horizontal scrollbar isn't needed (and isn't shown).

Also, don't force a height on progressbars because some widget styles may not show any bar with a forced height.

Closes https://github.com/lxqt/pavucontrol-qt/issues/99 and closes https://github.com/lxqt/pavucontrol-qt/issues/75