### PR TITLE
Wrapped the text of connecting error label

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -349,6 +349,12 @@
      <property name="alignment">
       <set>Qt::AlignCenter</set>
      </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+     </property>
     </widget>
    </item>
   </layout>

--- a/src/pavucontrol.cc
+++ b/src/pavucontrol.cc
@@ -619,11 +619,11 @@ gboolean connect_to_pulse(gpointer userdata) {
     w->setConnectingMessage();
     if (pa_context_connect(context, nullptr, PA_CONTEXT_NOFAIL, nullptr) < 0) {
         if (pa_context_errno(context) == PA_ERR_INVALID) {
-            w->setConnectingMessage(QObject::tr("Connection to PulseAudio failed. Automatic retry in 5s\n\n"
-                "In this case this is likely because PULSE_SERVER in the Environment/X11 Root Window Properties\n"
-                "or default-server in client.conf is misconfigured.\n"
-                "This situation can also arrise when PulseAudio crashed and left stale details in the X11 Root Window.\n"
-                "If this is the case, then PulseAudio should autospawn again, or if this is not configured you should\n"
+            w->setConnectingMessage(QObject::tr("Connection to PulseAudio failed. Automatic retry in 5s.<br><br>"
+                "In this case this is likely because PULSE_SERVER in the Environment/X11 Root Window Properties"
+                "or default-server in client.conf is misconfigured.<br>"
+                "This situation can also arrise when PulseAudio crashed and left stale details in the X11 Root Window.<br>"
+                "If this is the case, then PulseAudio should autospawn again, or if this is not configured you should"
                 "run start-pulseaudio-x11 manually.").toUtf8().constData());
             reconnect_timeout = 5;
         }


### PR DESCRIPTION
Because it can be long. Also, replaced `\n` with `<br>` because the former had no effect with HTML texts.

Fixes https://github.com/lxqt/pavucontrol-qt/issues/165

EDIT: Some instances of `\n` were redundant. They're removed.