### PR TITLE
Fix pa_stream leaks

### DIFF
--- a/src/mainwindow.cc
+++ b/src/mainwindow.cc
@@ -460,6 +460,7 @@ void MainWindow::createMonitorStreamForSinkInput(SinkInputWidget* w, uint32_t si
 
     if (w->peak) {
         pa_stream_disconnect(w->peak);
+        pa_stream_unref(w->peak);
         w->peak = nullptr;
     }
 

--- a/src/minimalstreamwidget.cc
+++ b/src/minimalstreamwidget.cc
@@ -41,6 +41,14 @@ MinimalStreamWidget::MinimalStreamWidget(QWidget *parent) :
     peakProgressBar->hide();
 }
 
+MinimalStreamWidget::~MinimalStreamWidget() {
+    if (peak != nullptr) {
+        pa_stream_disconnect(peak);
+        pa_stream_unref(peak);
+        peak = nullptr;
+    }
+}
+
 void MinimalStreamWidget::initPeakProgressBar(QGridLayout* channelsGrid) {
     channelsGrid->addWidget(peakProgressBar, channelsGrid->rowCount(), 0, 1, -1);
 }

--- a/src/minimalstreamwidget.h
+++ b/src/minimalstreamwidget.h
@@ -31,6 +31,7 @@ class MinimalStreamWidget : public QWidget {
     Q_OBJECT
 public:
     MinimalStreamWidget(QWidget* parent = nullptr);
+    ~MinimalStreamWidget() override;
     void initPeakProgressBar(QGridLayout* channelsGrid);
 
     QProgressBar* peakProgressBar;


### PR DESCRIPTION
Long-running instances of pavucontrol-qt will keep lots of leaked monitor streams open; when using pipewire as a pulse server, this results in pipewire keeping do-nothing monitoring ports around in the graph. This change fixes that by explicitly decrementing the refcount of each soon-to-be-unreachable pa_stream.