### PR TITLE
Change main window QDialog for QWidget

### DIFF
--- a/src/mainwindow.cc
+++ b/src/mainwindow.cc
@@ -67,7 +67,7 @@ struct source_port_prio_compare {
 };
 
 MainWindow::MainWindow():
-    QDialog(),
+    QWidget(),
     showSinkInputType(SINK_INPUT_CLIENT),
     showSinkType(SINK_ALL),
     showSourceOutputType(SOURCE_OUTPUT_CLIENT),

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -27,7 +27,7 @@
 #  include <pulse/ext-device-restore.h>
 #endif
 
-#include <QDialog>
+#include <QWidget>
 #include "ui_mainwindow.h"
 
 class CardWidget;
@@ -37,7 +37,7 @@ class SinkInputWidget;
 class SourceOutputWidget;
 class RoleWidget;
 
-class MainWindow : public QDialog, public Ui::MainWindow {
+class MainWindow : public QWidget, public Ui::MainWindow {
     Q_OBJECT
 public:
     MainWindow();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>MainWindow</class>
- <widget class="QDialog" name="MainWindow">
+ <widget class="QWidget" name="MainWindow">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/pavucontrol.cc
+++ b/src/pavucontrol.cc
@@ -49,6 +49,7 @@
 #include <QTranslator>
 #include <QCommandLineParser>
 #include <QCommandLineOption>
+#include <QScreen>
 #include <QString>
 
 static pa_context* context = nullptr;
@@ -694,6 +695,7 @@ int main(int argc, char *argv[]) {
 
     connect_to_pulse(mainWindow);
     if (reconnect_timeout >= 0) {
+        mainWindow->move(QGuiApplication::primaryScreen()->availableGeometry().center() - mainWindow->frameGeometry().center());
         mainWindow->show();
         app.exec();
     }


### PR DESCRIPTION
Hi, I used to ran the gtk version of pavucontrol in my machine but removed it after their gtk4 update, I was looking for an alternative and this port has been the best I've found. 

I run Qtile window manager and the issue I face is that I cannot see the window in the bar (i.e. [TaskList](https://docs.qtile.org/en/stable/manual/ref/widgets.html#tasklist)). This is because the window is marked as a dialog and ignore by qtile, this PR solves this issue by not creating the window as a dialog.

I checked for conflicts and no method specific of the [QDialog class](https://doc.qt.io/qt-6/qdialog.html) is used. I compiled and run this change in my machine and no problem has arise. I even installed LXQT and Openbox and the functionality is the same.