### PR TITLE
Update peak meter latency handling and define PEAKS_RATE

### DIFF
--- a/src/mainwindow.cc
+++ b/src/mainwindow.cc
@@ -423,7 +423,7 @@ pa_stream* MainWindow::createMonitorStreamForSource(uint32_t source_idx, uint32_
 
     ss.channels = 1;
     ss.format = PA_SAMPLE_FLOAT32;
-    ss.rate = 25;
+    ss.rate = PEAKS_RATE;
 
     memset(&attr, 0, sizeof(attr));
     attr.fragsize = sizeof(float);

--- a/src/minimalstreamwidget.cc
+++ b/src/minimalstreamwidget.cc
@@ -53,7 +53,7 @@ void MinimalStreamWidget::initPeakProgressBar(QGridLayout* channelsGrid) {
     channelsGrid->addWidget(peakProgressBar, channelsGrid->rowCount(), 0, 1, -1);
 }
 
-#define DECAY_STEP .04
+#define DECAY_STEP (1.0 / PEAKS_RATE)
 
 void MinimalStreamWidget::updatePeak(double v) {
 

--- a/src/pavucontrol.h
+++ b/src/pavucontrol.h
@@ -21,8 +21,6 @@
 #ifndef pavucontrol_h
 #define pavucontrol_h
 
-#include <signal.h>
-#include <string.h>
 #include <glib.h>
 
 #include <pulse/pulseaudio.h>
@@ -34,6 +32,9 @@
 
 #define HAVE_SOURCE_OUTPUT_VOLUMES PA_CHECK_VERSION(0,99,0)
 #define HAVE_EXT_DEVICE_RESTORE_API PA_CHECK_VERSION(0,99,0)
+
+/* Sample rate for peak-detect monitor streams */
+#define PEAKS_RATE 144
 
 enum SinkInputType {
     SINK_INPUT_ALL,


### PR DESCRIPTION
## 🎚️ Fix laggy/sticky peak meters

Peak meters felt noticeably choppier than upstream GTK `pavucontrol`. Root cause was in the monitor-stream setup, not a rendering issue:

- 📉 `ss.rate = 25` — the peak-detect monitor stream only sampled **25 times/sec**, so quick transients could be missed entirely for up to 40ms.
- 🐢 `DECAY_STEP = .04` — a magic number decoupled from the sample rate, tuned by trial and error.

- ✨ Added `#define PEAKS_RATE 144` in `src/pavucontrol.h`, matching upstream's current value.
- ⚡ `src/mainwindow.cc`: `ss.rate = 25` → `ss.rate = PEAKS_RATE` (144Hz sampling instead of 25Hz).
- 🎯 `src/minimalstreamwidget.cc`: `DECAY_STEP = .04` → `DECAY_STEP = (1.0 / PEAKS_RATE)`, keeping both constants tied together so they can't drift out of proportion again.
- Also removed some unnecessary include statements


Closes https://github.com/lxqt/pavucontrol-qt/issues/318
