### PR TITLE
Add port_device_name to PortInfo and update card description.

### DIFF
--- a/src/cardwidget.cc
+++ b/src/cardwidget.cc
@@ -22,6 +22,7 @@
 #include <config.h>
 #endif
 
+#include "pavucontrol.h"
 #include "cardwidget.h"
 
 /*** CardWidget ***/

--- a/src/cardwidget.h
+++ b/src/cardwidget.h
@@ -21,7 +21,6 @@
 #ifndef cardwidget_h
 #define cardwidget_h
 
-#include "pavucontrol.h"
 #include "ui_cardwidget.h"
 #include <QWidget>
 
@@ -29,6 +28,7 @@ class PortInfo {
 public:
       QByteArray name;
       QByteArray description;
+      QByteArray port_device_name;
       uint32_t priority;
       int available;
       int direction;

--- a/src/mainwindow.cc
+++ b/src/mainwindow.cc
@@ -223,6 +223,8 @@ void MainWindow::updateCard(const pa_card_info &info) {
 
         p.name = info.ports[i]->name;
         p.description = info.ports[i]->description;
+        /* device.product.name is not guaranteed to exist on a port */
+        p.port_device_name = pa_proplist_gets(info.ports[i]->proplist, PA_PROP_DEVICE_PRODUCT_NAME);
         p.priority = info.ports[i]->priority;
         p.available = info.ports[i]->available;
         p.direction = info.ports[i]->direction;
@@ -244,6 +246,10 @@ void MainWindow::updateCard(const pa_card_info &info) {
 
             if (std::find(port.profiles.begin(), port.profiles.end(), p_profile->name) == port.profiles.end())
                 continue;
+
+            /* If port has a device name, add it to the description */
+            if (!port.port_device_name.isEmpty())
+                desc += " [" + port.port_device_name + "]";
 
             if (port.available == PA_PORT_AVAILABLE_NO)
                 hasNo = true;


### PR DESCRIPTION
## 🖥️🔊 Show device.product.name for ports to fix HDMI output names

When multiple HDMI/DisplayPort outputs are available on a card, pavucontrol-qt shows generic, indistinguishable profile names like "Digital Stereo (HDMI) Output" for every port — even though PulseAudio/ALSA can expose the actual connected display's name (read from EDID) via the `device.product.name` port property. Users with multi-monitor / multi-HDMI setups can't tell which entry is which.

### 🔀 Ported from
🙏 Mirrors the fix already merged upstream in GTK pavucontrol ([pulseaudio/pavucontrol@bba68bd](https://github.com/pulseaudio/pavucontrol/commit/bba68bdf95ed48427c1d24a2fb0dd1b6f8400032)), adapted to the Qt/`QByteArray`-based data model used here.

Closes https://github.com/lxqt/pavucontrol-qt/issues/288