### PR TITLE
Update tooltip for default toggle button in DeviceWidget, before it was 'Set as fallback' now it's 'Set as default'

### DIFF
--- a/src/devicewidget.ui
+++ b/src/devicewidget.ui
@@ -82,7 +82,7 @@
      <item>
       <widget class="QToolButton" name="defaultToggleButton">
        <property name="toolTip">
-        <string>Set as fallback</string>
+        <string>Set as default</string>
        </property>
        <property name="icon">
         <iconset theme="applications-multimedia"/>


### PR DESCRIPTION
Closes https://github.com/lxqt/pavucontrol-qt/issues/301