### PR TITLE
Handle stream state changes and prevent memory leaks in MinimalStreamWidget

### DIFF
--- a/src/mainwindow.cc
+++ b/src/mainwindow.cc
@@ -381,6 +381,31 @@ static void suspended_callback(pa_stream *s, void *userdata) {
         w->updateVolumeMeter(pa_stream_get_device_index(s), PA_INVALID_INDEX, -1);
 }
 
+/* Monitoring streams can fail asynchronously (e.g. the device they read from
+ * disappears). Without this, a failed stream is never unref'd and the widget
+ * is left believing it still has a live peak stream. */
+static void stream_state_callback(pa_stream *s, void *userdata) {
+    MinimalStreamWidget *w = static_cast<MinimalStreamWidget*>(userdata);
+
+    switch (pa_stream_get_state(s)) {
+        case PA_STREAM_FAILED:
+            /* Not fatal: the device this peak stream was reading from likely
+             * just disappeared. show_error() quits the whole app, which
+             * would be a massive overreaction to one dead meter. */
+            g_debug("%s", MainWindow::tr("Monitoring stream failed").toUtf8().constData());
+            /* fall through */
+        case PA_STREAM_TERMINATED:
+            if (w->peak == s) {
+                pa_stream_unref(s);
+                w->peak = nullptr;
+            }
+            break;
+
+        default:
+            break;
+    }
+}
+
 static void read_callback(pa_stream *s, size_t length, void *userdata) {
     MainWindow *w = static_cast<MainWindow*>(userdata);
     const void *data;
@@ -414,7 +439,7 @@ static void read_callback(pa_stream *s, size_t length, void *userdata) {
     w->updateVolumeMeter(pa_stream_get_device_index(s), pa_stream_get_monitor_stream(s), v);
 }
 
-pa_stream* MainWindow::createMonitorStreamForSource(uint32_t source_idx, uint32_t stream_idx = -1, bool suspend = false) {
+pa_stream* MainWindow::createMonitorStreamForSource(MinimalStreamWidget *w, uint32_t source_idx, uint32_t stream_idx = -1, bool suspend = false) {
     pa_stream *s;
     char t[16];
     pa_buffer_attr attr;
@@ -441,6 +466,7 @@ pa_stream* MainWindow::createMonitorStreamForSource(uint32_t source_idx, uint32_
 
     pa_stream_set_read_callback(s, read_callback, this);
     pa_stream_set_suspended_callback(s, suspended_callback, this);
+    pa_stream_set_state_callback(s, stream_state_callback, w);
 
     flags = (pa_stream_flags_t) (PA_STREAM_DONT_MOVE | PA_STREAM_PEAK_DETECT | PA_STREAM_ADJUST_LATENCY |
                                  (suspend ? PA_STREAM_DONT_INHIBIT_AUTO_SUSPEND : PA_STREAM_NOFLAGS) |
@@ -459,12 +485,13 @@ void MainWindow::createMonitorStreamForSinkInput(SinkInputWidget* w, uint32_t si
         return;
 
     if (w->peak) {
+        pa_stream_set_state_callback(w->peak, nullptr, nullptr);
         pa_stream_disconnect(w->peak);
         pa_stream_unref(w->peak);
         w->peak = nullptr;
     }
 
-    w->peak = createMonitorStreamForSource(sinkWidgets[sink_idx]->monitor_index, w->index);
+    w->peak = createMonitorStreamForSource(w, sinkWidgets[sink_idx]->monitor_index, w->index);
 }
 
 void MainWindow::updateSource(const pa_source_info &info) {
@@ -488,7 +515,7 @@ void MainWindow::updateSource(const pa_source_info &info) {
         w->setVolumeMeterVisible(showVolumeMetersCheckButton->isChecked());
 
         if (pa_context_get_server_protocol_version(get_context()) >= 13)
-            w->peak = createMonitorStreamForSource(info.index, -1, !!(info.flags & PA_SOURCE_NETWORK));
+            w->peak = createMonitorStreamForSource(w, info.index, -1, !!(info.flags & PA_SOURCE_NETWORK));
     }
 
     w->updating = true;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -36,6 +36,7 @@ class SourceWidget;
 class SinkInputWidget;
 class SourceOutputWidget;
 class RoleWidget;
+class MinimalStreamWidget;
 
 class MainWindow : public QDialog, public Ui::MainWindow {
     Q_OBJECT
@@ -90,7 +91,7 @@ public:
     void setConnectionState(gboolean connected);
     void updateDeviceVisibility();
     void reallyUpdateDeviceVisibility();
-    pa_stream* createMonitorStreamForSource(uint32_t source_idx, uint32_t stream_idx, bool suspend);
+    pa_stream* createMonitorStreamForSource(MinimalStreamWidget *w, uint32_t source_idx, uint32_t stream_idx, bool suspend);
     void createMonitorStreamForSinkInput(SinkInputWidget* w, uint32_t sink_idx);
 
     void setIconFromProplist(QLabel *icon, pa_proplist *l, const char *name);

--- a/src/minimalstreamwidget.cc
+++ b/src/minimalstreamwidget.cc
@@ -43,6 +43,7 @@ MinimalStreamWidget::MinimalStreamWidget(QWidget *parent) :
 
 MinimalStreamWidget::~MinimalStreamWidget() {
     if (peak != nullptr) {
+        pa_stream_set_state_callback(peak, nullptr, nullptr);
         pa_stream_disconnect(peak);
         pa_stream_unref(peak);
         peak = nullptr;


### PR DESCRIPTION
## 🚨🔊 Handle PA_STREAM_FAILED for peak-detect monitor streams                                       
                                                                                                                                                                                                                                                                                                                                                                           
`createMonitorStreamForSource()` in [mainwindow.cc](src/mainwindow.cc) creates a "Peak detect" record stream for every sink/source to drive the volume meters, and wires up `read_callback` + `suspended_callback` on it — but **never** `pa_stream_set_state_callback()`. 🙈                                     
                                                                                                      
So when a device disappears or its stream otherwise dies mid-session, `PA_STREAM_FAILED` (and `PA_STREAM_TERMINATED`) go completely unhandled:                                                              
- 🧟 The `pa_stream*` is never `unref()`'d → leaked                                                   
- 👻 The owning widget's `peak` pointer stays non-null, pointing at a dead stream                     
- 📉 The meter silently stops updating with no recovery path                                          
                                                                                                      
Exactly the class of bug described upstream for GTK `pavucontrol`.                                      
                                                                                                      
- **Did not** reuse the existing `show_error()` helper for `PA_STREAM_FAILED` — every other caller uses it for fatal, connection-level failures and it calls `qApp->quit()`. Using it here would mean unplugging *any single* monitored device silently closed the whole app — worse than the original bug. Used `g_debug()` instead (the pattern already used elsewhere for non-fatal, recoverable failures).

### 🧪 How to test
This one was not that easy to test but I managed to confirm it works:
1. Rebuilt with `-DCMAKE_BUILD_TYPE=Debug` for proper symbols.
2. Ran the app under `gdb` with a breakpoint on `stream_state_callback`, logging state + pointers on every hit.
3. Used `pw-cli destroy <node-id>` to directly kill the PipeWire node behind one of pavucontrol-qt's own "Peak detect" streams *while its source stayed alive* — a clean, targeted trigger of `PA_STREAM_FAILED` on a live stream (not just a device-removal event, which already worked fine before this fix via the widget destructor).
4. Confirmed: `pa_stream_get_state(s) == PA_STREAM_FAILED`, `w->peak == s` (guard matched, cleanup ran), and **the app kept running** — no crash, no hang, no surprise quit.
5. Also stress-tested with repeated `pactl load-module module-null-sink` / `unload-module` cycles (full device add/remove) — stable throughout, no leaked CPU, no leftover state.

Closes https://github.com/lxqt/pavucontrol-qt/issues/289