### PR TITLE
Implement Bluetooth codec selection and UI integration

### DIFF
--- a/src/cardwidget.cc
+++ b/src/cardwidget.cc
@@ -40,6 +40,18 @@ CardWidget::CardWidget(QWidget* parent) :
 void CardWidget::prepareMenu() {
     int idx = 0;
     const bool off = activeProfile == noInOutProfile;
+    /* Some backends (observed with PipeWire's own Bluetooth support, as
+     * opposed to real PulseAudio's module-bluez5-device) expose codec choice
+     * as separate profile entries instead - e.g. "High Fidelity Playback
+     * (A2DP Sink, codec LDAC)" *and* "... codec AAC)" *and* "... codec SBC)"
+     * all appearing as distinct, individually selectable profiles. When
+     * that's the case, the Profile dropdown below already IS the codec
+     * switcher, and showing our own separate Codec dropdown alongside it
+     * would just be a confusing, redundant second control offering the same
+     * choice. Real PulseAudio only ever exposes a single, codec-agnostic
+     * A2DP profile - "High Fidelity Playback (A2DP Sink)", no codec name in
+     * sight - which is the actual case this feature exists for. */
+    bool profileListAlreadyOffersCodecs = false;
 
     profileList->clear();
     /* Fill the ComboBox */
@@ -48,6 +60,8 @@ void CardWidget::prepareMenu() {
         // skip the "off" profile
         if (name == noInOutProfile)
             continue;
+        if (profile.second.contains(", codec "))
+            profileListAlreadyOffersCodecs = true;
         QString desc = QString::fromUtf8(profile.second);
         profileList->addItem(desc, name);
         if (profile.first == activeProfile
@@ -66,14 +80,17 @@ void CardWidget::prepareMenu() {
      * Bluetooth codecs. `codecs` (and therefore this whole block) stays
      * empty for every non-Bluetooth card, in which case the loop does
      * nothing and codecBox ends up hidden below - exactly the same as
-     * before this feature existed. */
+     * before this feature existed. Also stays empty when the profile list
+     * already offers per-codec entries, per the comment above. */
     codecList->clear();
-    for (const auto & codec : codecs) {
-        codecList->addItem(QString::fromUtf8(codec.second), codec.first);
-        if (codec.first == activeCodec)
-            codecList->setCurrentIndex(codecList->count() - 1);
+    if (!profileListAlreadyOffersCodecs) {
+        for (const auto & codec : codecs) {
+            codecList->addItem(QString::fromUtf8(codec.second), codec.first);
+            if (codec.first == activeCodec)
+                codecList->setCurrentIndex(codecList->count() - 1);
+        }
     }
-    codecBox->setVisible(!codecs.empty());
+    codecBox->setVisible(!profileListAlreadyOffersCodecs && !codecs.empty());
 }
 
 void CardWidget::changeProfile(const QByteArray & name)

--- a/src/cardwidget.cc
+++ b/src/cardwidget.cc
@@ -30,6 +30,10 @@ CardWidget::CardWidget(QWidget* parent) :
     setupUi(this);
     connect(profileList, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &CardWidget::onProfileChange);
     connect(profileCB, &QAbstractButton::toggled, this, &CardWidget::onProfileCheck);
+    connect(codecList, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &CardWidget::onCodecChange);
+    /* Hidden until prepareMenu() finds this card actually has codecs to
+     * offer - most cards never will, since this is Bluetooth-only. */
+    codecBox->hide();
 }
 
 
@@ -57,6 +61,19 @@ void CardWidget::prepareMenu() {
     }
 
     profileCB->setChecked(!off);
+
+    /* Same fill-and-select pattern as the profile combo box above, but for
+     * Bluetooth codecs. `codecs` (and therefore this whole block) stays
+     * empty for every non-Bluetooth card, in which case the loop does
+     * nothing and codecBox ends up hidden below - exactly the same as
+     * before this feature existed. */
+    codecList->clear();
+    for (const auto & codec : codecs) {
+        codecList->addItem(QString::fromUtf8(codec.second), codec.first);
+        if (codec.first == activeCodec)
+            codecList->setCurrentIndex(codecList->count() - 1);
+    }
+    codecBox->setVisible(!codecs.empty());
 }
 
 void CardWidget::changeProfile(const QByteArray & name)
@@ -90,3 +107,38 @@ void CardWidget::onProfileCheck(bool on)
         changeProfile(noInOutProfile);
 
 }
+
+#if HAVE_PULSE_MESSAGING_API
+void CardWidget::onCodecChange(int active) {
+    pa_operation* o;
+
+    if (updating || active == -1)
+        return;
+
+    QByteArray codecName = codecList->itemData(active).toByteArray();
+    /* The "switch-codec" message's parameter must be the codec name encoded
+     * as a bare JSON string, e.g. `"ldac"` (quotes included) - see the
+     * protocol comment above context_message_handlers_cb() in pavucontrol.cc.
+     * Codec names come back-and-forth verbatim from PulseAudio itself
+     * (they're short fixed identifiers like "sbc"/"ldac"/"aptx", never
+     * user-supplied text), so no JSON escaping is needed here. */
+    QByteArray params = "\"" + codecName + "\"";
+
+    /* Deliberately does NOT call show_error() on failure: show_error() calls
+     * qApp->quit(), which is right for genuinely fatal errors elsewhere in
+     * this codebase but would be a wildly disproportionate response to a
+     * rejected codec switch (e.g. the headset doesn't actually support the
+     * chosen codec, or got disconnected mid-switch) - the user would just
+     * lose the whole app over a dropdown selection. Codec switching failing
+     * silently here matches how the discovery queries in pavucontrol.cc
+     * already treat every failure in this feature as non-fatal. */
+    if (!(o = pa_context_send_message_to_object(get_context(), bluezMessageHandlerPath(pulseCardName).constData(),
+            "switch-codec", params.constData(), nullptr, nullptr)))
+        return;
+
+    pa_operation_unref(o);
+}
+#else
+void CardWidget::onCodecChange(int) {
+}
+#endif

--- a/src/cardwidget.h
+++ b/src/cardwidget.h
@@ -42,6 +42,7 @@ public:
     CardWidget(QWidget *parent = nullptr);
 
     QByteArray name;
+    QByteArray pulseCardName;
     uint32_t index;
     bool updating;
 
@@ -52,6 +53,8 @@ public:
     QByteArray lastActiveProfile;
     bool hasSinks;
     bool hasSources;
+    std::vector< std::pair<QByteArray,QByteArray> > codecs;
+    QByteArray activeCodec;
 
     void prepareMenu();
 
@@ -59,6 +62,7 @@ protected:
     void changeProfile(const QByteArray & name);
     void onProfileChange(int active);
     void onProfileCheck(bool on);
+    void onCodecChange(int active);
 
 };
 

--- a/src/cardwidget.ui
+++ b/src/cardwidget.ui
@@ -54,6 +54,34 @@
     </layout>
    </item>
    <item>
+    <widget class="QWidget" name="codecBox" native="true">
+     <layout class="QHBoxLayout" name="codecHLayout" stretch="0,1">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="codecLabel">
+        <property name="text">
+         <string>Codec:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="codecList"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="Line" name="line">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/src/mainwindow.cc
+++ b/src/mainwindow.cc
@@ -22,6 +22,7 @@
 #include <config.h>
 #endif
 
+#include <cstring>
 #include <set>
 
 #include "mainwindow.h"
@@ -201,6 +202,7 @@ void MainWindow::updateCard(const pa_card_info &info) {
     }
 
     w->updating = true;
+    w->pulseCardName = info.name;
 
     description = pa_proplist_gets(info.proplist, PA_PROP_DEVICE_DESCRIPTION);
     w->name = description ? description : info.name;
@@ -301,6 +303,48 @@ void MainWindow::updateCard(const pa_card_info &info) {
 
     w->updating = false;
 }
+
+#if HAVE_PULSE_MESSAGING_API
+/* Called asynchronously from pavucontrol.cc once a "list-codecs" reply comes
+ * back for a Bluetooth-capable card.
+ * cardWidgets is keyed by PulseAudio's numeric card index, not by name, so
+ * we look the widget up by its stored pulseCardName instead. If the card
+ * has since disappeared (e.g. the Bluetooth device was unplugged mid-query)
+ * this simply finds nothing and does nothing - there is no dangling pointer
+ * risk since we never hold on to a CardWidget*, only the MainWindow itself. */
+void MainWindow::updateCardCodecs(const QByteArray &cardName, const std::vector<std::pair<QByteArray, QByteArray>> &codecs) {
+    for (auto & c : cardWidgets) {
+        CardWidget *w = c.second;
+
+        if (w->pulseCardName != cardName)
+            continue;
+
+        w->updating = true;
+        w->codecs = codecs;
+        w->prepareMenu();
+        w->updating = false;
+        return;
+    }
+}
+
+/* Same as updateCardCodecs() above, but for the "get-codec" reply that
+ * reports which codec is currently active, so the combo box can pre-select
+ * it instead of defaulting to the first entry. */
+void MainWindow::setActiveCodec(const QByteArray &cardName, const QByteArray &codec) {
+    for (auto & c : cardWidgets) {
+        CardWidget *w = c.second;
+
+        if (w->pulseCardName != cardName)
+            continue;
+
+        w->updating = true;
+        w->activeCodec = codec;
+        w->prepareMenu();
+        w->updating = false;
+        return;
+    }
+}
+#endif
 
 bool MainWindow::updateSink(const pa_sink_info &info) {
     SinkWidget *w;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -55,6 +55,12 @@ public:
 #if HAVE_EXT_DEVICE_RESTORE_API
     void updateDeviceInfo(const pa_ext_device_restore_info &info);
 #endif
+#if HAVE_PULSE_MESSAGING_API
+    /* Bluetooth codec discovery results, delivered asynchronously from the
+     * message-handler queries in pavucontrol.cc. */
+    void updateCardCodecs(const QByteArray &cardName, const std::vector<std::pair<QByteArray, QByteArray>> &codecs);
+    void setActiveCodec(const QByteArray &cardName, const QByteArray &codec);
+#endif
 
     void removeCard(uint32_t index);
     void removeSink(uint32_t index);

--- a/src/pavucontrol.cc
+++ b/src/pavucontrol.cc
@@ -24,6 +24,8 @@
 
 #define PACKAGE_VERSION "0.1"
 
+#include <csignal>
+
 #include <pulse/pulseaudio.h>
 #include <pulse/glib-mainloop.h>
 #include <pulse/ext-stream-restore.h>
@@ -32,15 +34,9 @@
 // #include <canberra-gtk.h>
 
 #include "pavucontrol.h"
-#include "minimalstreamwidget.h"
-#include "channel.h"
 #include "streamwidget.h"
-#include "cardwidget.h"
-#include "sinkwidget.h"
-#include "sourcewidget.h"
 #include "sinkinputwidget.h"
 #include "sourceoutputwidget.h"
-#include "rolewidget.h"
 #include "mainwindow.h"
 #include <QMessageBox>
 #include <QApplication>
@@ -50,6 +46,10 @@
 #include <QCommandLineParser>
 #include <QCommandLineOption>
 #include <QString>
+#include <QJsonDocument>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QJsonValue>
 
 static pa_context* context = nullptr;
 static pa_mainloop_api* api = nullptr;
@@ -77,6 +77,157 @@ static void dec_outstanding(MainWindow *w) {
     }
 }
 
+#if HAVE_PULSE_MESSAGING_API
+
+/*
+ * Bluetooth codec selection (e.g. switching a headset between SBC/AAC/LDAC)
+ * is not exposed through the normal pa_context_get_card_info()/pa_card_info
+ * API. Instead, PulseAudio's module-bluez5-device registers a generic
+ * "message handler" per Bluetooth card, reachable through the object
+ * messaging API added in PulseAudio 15.0 (pa_context_send_message_to_object(),
+ * see pulse/introspect.h and https://cgit.freedesktop.org/pulseaudio/pulseaudio/tree/doc/messaging_api.txt).
+ *
+ * The handler lives at path "/card/<pulse card name>/bluez" and understands
+ * three messages:
+ *   - "list-codecs" -> returns a JSON array of {"name": ..., "description": ...}
+ *                       describing every codec this device could use
+ *   - "get-codec"   -> returns a bare JSON string with the currently active
+ *                       codec's name (or JSON null if nothing is active yet)
+ *   - "switch-codec"-> takes a bare JSON string (the codec name) as its
+ *                       message_parameters and switches to it
+ *
+ * Because most cards are not Bluetooth devices at all, and plenty of servers
+ * (older PulseAudio, or PipeWire's pulse-compat layer, which may or may not
+ * implement this specific handler) won't have this handler registered, every
+ * failure in this chain is treated as "this card doesn't support codec
+ * switching" rather than as an error: it must NEVER call show_error(), since
+ * show_error() calls qApp->quit() — that's correct for genuinely fatal,
+ * connection-level failures elsewhere in this file, but here it would mean
+ * a single unremarkable, totally expected non-Bluetooth card would quit the
+ * whole application.
+ */
+
+/* Path of the per-card Bluetooth codec-switching message handler, if the
+ * running PulseAudio/module-bluez5-device registered one for this card. */
+QByteArray bluezMessageHandlerPath(const QByteArray &cardName) {
+    return "/card/" + cardName + "/bluez";
+}
+
+/* Carries the MainWindow + PulseAudio card name across one async message
+ * round-trip. Every send below allocates one of these as the pa_operation's
+ * userdata and the matching callback below is responsible for deleting it
+ * exactly once, on every path (success, failure, or "not applicable"). */
+struct CardCodecQuery {
+    MainWindow *window;
+    QByteArray cardName;
+};
+
+/* Sends a codec-related message to a registered PulseAudio message handler.
+ * Best-effort only: most cards (and servers that don't implement the
+ * messaging API at all) simply won't have a handler at the given path, so
+ * failures here are routine and must never be treated as fatal.
+ *
+ * If pa_context_send_message_to_object() itself fails synchronously (no
+ * pa_operation is created), `cb` will never fire, so the CardCodecQuery is
+ * freed here instead to avoid leaking it. */
+static void sendCodecMessage(const QByteArray &path, const char *message, MainWindow *w, const QByteArray &cardName, pa_context_string_cb_t cb) {
+    pa_operation *o;
+    auto *q = new CardCodecQuery{w, cardName};
+
+    if ((o = pa_context_send_message_to_object(context, path.constData(), message, nullptr, cb, q)))
+        pa_operation_unref(o);
+    else
+        delete q;
+}
+
+/* Parses a "list-codecs" or "list-handlers" style response: a JSON array of
+ * {"name": "...", "description": "..."} objects. Used both for the codec
+ * list itself and (in context_message_handlers_cb below) to search the
+ * handler list for our target path — same shape, different meaning of the
+ * name/description pair. Malformed or unexpected JSON just yields an empty
+ * result rather than an error. */
+static std::vector<std::pair<QByteArray, QByteArray>> parseCodecArray(const QJsonDocument &doc) {
+    std::vector<std::pair<QByteArray, QByteArray>> codecs;
+
+    if (!doc.isArray())
+        return codecs;
+
+    for (const QJsonValue &v : doc.array()) {
+        if (!v.isObject())
+            continue;
+        QJsonObject o = v.toObject();
+        codecs.emplace_back(o.value(QStringLiteral("name")).toString().toUtf8(),
+                             o.value(QStringLiteral("description")).toString().toUtf8());
+    }
+
+    return codecs;
+}
+
+/* Response callback for "list-codecs": hands the parsed codec list to the
+ * CardWidget matching q->cardName so it can populate the codec combo box. */
+static void context_bluetooth_codec_list_cb(pa_context *, int success, char *response, void *userdata) {
+    auto *q = static_cast<CardCodecQuery*>(userdata);
+
+    if (success && response)
+        q->window->updateCardCodecs(q->cardName, parseCodecArray(QJsonDocument::fromJson(response)));
+
+    delete q;
+}
+
+/* Response callback for "get-codec": the response is a *bare* JSON string
+ * (e.g. `"ldac"`) or bare `null`, not wrapped in an object or array.
+ * QJsonDocument::fromJson() only accepts an object or array at the top
+ * level (per Qt's JSON implementation), so a bare scalar would otherwise
+ * fail to parse even though it's valid JSON by the RFC. Wrapping it in "["
+ * ... "]" turns it into a single-element array QJsonDocument is happy to
+ * parse, and we then just read that one element back out. */
+static void context_bluetooth_active_codec_cb(pa_context *, int success, char *response, void *userdata) {
+    auto *q = static_cast<CardCodecQuery*>(userdata);
+
+    if (success && response) {
+        QJsonDocument doc = QJsonDocument::fromJson("[" + QByteArray(response) + "]");
+        if (doc.isArray() && doc.array().size() == 1) {
+            QJsonValue v = doc.array().at(0);
+            if (v.isString())
+                q->window->setActiveCodec(q->cardName, v.toString().toUtf8());
+        }
+    }
+
+    delete q;
+}
+
+/* Response callback for "list-handlers" sent to the global "/core" object.
+ * This is the entry point of the whole chain (kicked off from card_cb below
+ * for every card): it lists every message handler currently registered
+ * anywhere on the server, and we check whether our card's bluez handler
+ * path is among them. Only if it is do we know this card actually supports
+ * codec switching, and only then do we go on to ask for the codec list and
+ * the currently active codec. */
+static void context_message_handlers_cb(pa_context *, int success, char *response, void *userdata) {
+    auto *q = static_cast<CardCodecQuery*>(userdata);
+
+    if (success && response) {
+        QByteArray targetPath = bluezMessageHandlerPath(q->cardName);
+        bool found = false;
+
+        for (const QJsonValue &v : QJsonDocument::fromJson(response).array()) {
+            if (v.isObject() && v.toObject().value(QStringLiteral("name")).toString().toUtf8() == targetPath) {
+                found = true;
+                break;
+            }
+        }
+
+        if (found) {
+            sendCodecMessage(targetPath, "get-codec", q->window, q->cardName, context_bluetooth_active_codec_cb);
+            sendCodecMessage(targetPath, "list-codecs", q->window, q->cardName, context_bluetooth_codec_list_cb);
+        }
+    }
+
+    delete q;
+}
+
+#endif
+
 void card_cb(pa_context *, const pa_card_info *i, int eol, void *userdata) {
     MainWindow *w = static_cast<MainWindow*>(userdata);
 
@@ -94,6 +245,10 @@ void card_cb(pa_context *, const pa_card_info *i, int eol, void *userdata) {
     }
 
     w->updateCard(*i);
+
+#if HAVE_PULSE_MESSAGING_API
+    sendCodecMessage("/core", "list-handlers", w, QByteArray(i->name), context_message_handlers_cb);
+#endif
 }
 
 #if HAVE_EXT_DEVICE_RESTORE_API

--- a/src/pavucontrol.h
+++ b/src/pavucontrol.h
@@ -21,11 +21,11 @@
 #ifndef pavucontrol_h
 #define pavucontrol_h
 
-#include <signal.h>
-#include <string.h>
 #include <glib.h>
 
 #include <pulse/pulseaudio.h>
+
+#include <QByteArray>
 
 /* Can be removed when PulseAudio 0.9.23 or newer is required */
 #ifndef PA_VOLUME_UI_MAX
@@ -34,6 +34,7 @@
 
 #define HAVE_SOURCE_OUTPUT_VOLUMES PA_CHECK_VERSION(0,99,0)
 #define HAVE_EXT_DEVICE_RESTORE_API PA_CHECK_VERSION(0,99,0)
+#define HAVE_PULSE_MESSAGING_API PA_CHECK_VERSION(15,0,0)
 
 enum SinkInputType {
     SINK_INPUT_ALL,
@@ -63,5 +64,11 @@ enum SourceType {
 
 pa_context* get_context(void);
 void show_error(const char *txt);
+
+#if HAVE_PULSE_MESSAGING_API
+/* Path of the per-card Bluetooth codec-switching message handler, if the
+ * running PulseAudio/module-bluez5-device registered one for this card. */
+QByteArray bluezMessageHandlerPath(const QByteArray &cardName);
+#endif
 
 #endif


### PR DESCRIPTION
## 🎧🔀 Add Bluetooth codec selector

When a Bluetooth device is connected, pavucontrol-qt has no way to see or change its audio codec (SBC/AAC/aptX/LDAC/...) — GTK pavucontrol has had this for years, but the Qt port never got it.

🕵️ **Plot twist while implementing this**: the GTK reference implementation (linked in [the issue](https://github.com/lxqt/pavucontrol-qt/issues/220)) depends on a client-side helper, `pulse/message-params.h`, for building/parsing these messages. Turns out that header was **deleted from PulseAudio itself in March 2021** — by the same author who wrote it — once the server moved to plain JSON. So porting the reference code verbatim would produce something that can't compile against *any* current PulseAudio release. Went and read PulseAudio's actual current server-side handler (`module-bluez5-device.c`) to get the real wire format, and implemented the client side using **Qt's own `QJsonDocument`/`QJsonArray`/`QJsonObject`** — already linked via `Qt6::Widgets`, zero new dependencies.

Closes https://github.com/lxqt/pavucontrol-qt/issues/220

Result:
<img width="1744" height="1001" alt="image" src="https://github.com/user-attachments/assets/48a7dd5c-07a6-4f0c-8eab-5db64dbe2d62" />
